### PR TITLE
version 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 byteorder = "1"
 thiserror = "1"
-winapi = { version = "0.3", features = [ "ntdef", "winnt" ] }
+winapi = { version = "0.3", features = [ "ntdef", "winnt", "ntstatus" ] }
 widestring = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winregnt"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["russ <rustysec@github.com>"]
 edition = "2018"
 

--- a/examples/create_values.rs
+++ b/examples/create_values.rs
@@ -1,0 +1,17 @@
+extern crate winregnt;
+
+use winregnt::RegKey;
+
+fn main() {
+    // Open the registry key
+    let mut key = RegKey::open_write(r"\Registry\Machine\Software\DestroyMe").unwrap();
+
+    key.write_dword_value("DwordValue", 1337)
+        .expect("could not create dword value!");
+
+    key.write_qword_value("QwordValue", 13371337)
+        .expect("could not create qword value!");
+
+    key.write_string_value("StringValue", "Hello, world!")
+        .expect("could not create string value!");
+}

--- a/examples/delete_key.rs
+++ b/examples/delete_key.rs
@@ -1,0 +1,8 @@
+extern crate winregnt;
+
+use winregnt::RegKey;
+
+fn main() {
+    let key = RegKey::open_write(r"\Registry\Machine\Software\DestroyMe").unwrap();
+    key.delete().expect("Couldn't delete the key");
+}

--- a/examples/delete_value.rs
+++ b/examples/delete_value.rs
@@ -1,0 +1,11 @@
+extern crate winregnt;
+
+use winregnt::RegKey;
+
+fn main() {
+    // Open the registry key
+    let key = RegKey::open_write(r"\Registry\Machine\Software\DestroyMe").unwrap();
+    // Delete the value
+    key.delete_value("DeleteThis")
+        .expect("Couldn't delete the value");
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -336,6 +336,14 @@ extern "system" {
     ) -> u32;
     pub fn NtDeleteValueKey(handle: HANDLE, value_name: *mut UNICODE_STRING) -> u32;
     pub fn NtDeleteKey(handle: HANDLE) -> u32;
+    pub fn NtSetValueKey(
+        KeyHandle: HANDLE,
+        ValueName: *mut UNICODE_STRING,
+        TitleIndex: ULONG,
+        Type: ULONG,
+        Data: PVOID,
+        DataSize: ULONG,
+    ) -> u32;
 }
 
 pub(crate) fn enumerate_value_key(handle: HANDLE, index: ULONG) -> Option<Vec<u8>> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -334,6 +334,8 @@ extern "system" {
         access: ACCESS_MASK,
         attr: *const OBJECT_ATTRIBUTES,
     ) -> u32;
+    pub fn NtDeleteValueKey(handle: HANDLE, value_name: *mut UNICODE_STRING) -> u32;
+    pub fn NtDeleteKey(handle: HANDLE) -> u32;
 }
 
 pub(crate) fn enumerate_value_key(handle: HANDLE, index: ULONG) -> Option<Vec<u8>> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,6 +94,10 @@ pub enum RegValueError {
     /// The specified value name was not found
     #[error("Could not operate on value, the specified name was not found")]
     NameNotFound,
+
+    /// Unable to write a value
+    #[error("Unable to write value to registry key: {0}")]
+    Write(u32),
 }
 
 /// Errors while operating on a registry key

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,14 @@ pub enum Error {
     /// Converting registry data to string failed
     #[error("Could not convert registry data to string: {0}")]
     StringConversion(#[from] std::string::FromUtf16Error),
+
+    /// Problem operating on registry key
+    #[error("A problem occurred while operating on key: {source}")]
+    RegKeyError {
+        /// Source of this error
+        #[from]
+        source: RegKeyError,
+    },
 }
 
 /// Errors encountered while processing subkeys
@@ -70,4 +78,32 @@ pub enum RegValueError {
     /// Could not read key information
     #[error("Could not read key basic information: {0}")]
     ReadKeyBasicInformation(#[source] std::io::Error),
+
+    /// Could not operate on value due to permission denied
+    #[error("Could not operate on value, permission denied")]
+    AccessDenied,
+
+    /// Could not operate on value because the handle is not valid
+    #[error("Could not operate on value, handle is no longer valid")]
+    InvalidHandle,
+
+    /// Could not operate on value because there are insufficient resources
+    #[error("Could not operate on value, insufficient resources")]
+    InsufficientResources,
+
+    /// The specified value name was not found
+    #[error("Could not operate on value, the specified name was not found")]
+    NameNotFound,
+}
+
+/// Errors while operating on a registry key
+#[derive(Debug, Error)]
+pub enum RegKeyError {
+    /// Could not delete key due to permission denied
+    #[error("Could not delete key, permission denied")]
+    DeleteAccessDenied,
+
+    /// Could not delete key because the handle is not valid
+    #[error("Could not delete key, handle is no longer valid")]
+    DeleteInvalidHandle,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,14 +39,17 @@ pub use crate::error::*;
 use crate::reg_key_iterator::*;
 use crate::reg_value_iterator::*;
 use crate::unicode_string::*;
-use std::ffi::OsString;
-use std::mem::zeroed;
-use std::os::windows::ffi::OsStrExt;
-use std::ptr::null_mut;
-use winapi::shared::ntdef::{
-    InitializeObjectAttributes, HANDLE, OBJECT_ATTRIBUTES, OBJ_CASE_INSENSITIVE,
+use std::{ffi::OsString, mem::zeroed, os::windows::ffi::OsStrExt, ptr::null_mut};
+use winapi::{
+    shared::{
+        ntdef::{InitializeObjectAttributes, HANDLE, OBJECT_ATTRIBUTES, OBJ_CASE_INSENSITIVE},
+        ntstatus::{
+            STATUS_ACCESS_DENIED, STATUS_INSUFFICIENT_RESOURCES, STATUS_INVALID_HANDLE,
+            STATUS_OBJECT_NAME_NOT_FOUND,
+        },
+    },
+    um::winnt::{KEY_READ, KEY_WRITE},
 };
-use winapi::um::winnt::KEY_READ;
 
 /// Result wrapping WinRegNt errors
 pub type Result<T> = std::result::Result<T, error::Error>;
@@ -69,7 +72,7 @@ impl Drop for RegKey {
 }
 
 impl RegKey {
-    /// opens a registry key
+    /// opens a registry key as read only
     ///
     /// # Examples
     ///
@@ -78,12 +81,63 @@ impl RegKey {
     /// assert!(RegKey::open(r"\Registry\Machine\Software\Microsoft\Windows\CurrentVersion\Run").is_ok());
     /// ```
     ///
-    pub fn open<S: Into<String> + Clone>(name: S) -> Result<RegKey> {
-        let name = name.into();
+    pub fn open<S: AsRef<str>>(name: S) -> Result<RegKey> {
+        Self::open_key(name, KEY_READ)
+    }
+
+    /// opens a registry key with write permissions
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use winregnt::RegKey;
+    /// assert!(RegKey::open_write(r"\Registry\Machine\Software\Microsoft\Windows\CurrentVersion\Run").is_ok());
+    /// ```
+    ///
+    pub fn open_write<S: AsRef<str>>(name: S) -> Result<RegKey> {
+        Self::open_key(name, KEY_WRITE)
+    }
+
+    /// get an sub key enumerator
+    pub fn enum_keys(&self) -> RegKeyIterator {
+        RegKeyIterator::new(&self)
+    }
+
+    /// get a key value iterator
+    pub fn enum_values(&self) -> RegValueIterator {
+        RegValueIterator::new(&self.handle)
+    }
+
+    /// delete the current key
+    pub fn delete(&self) -> Result<()> {
+        match unsafe { api::NtDeleteKey(self.handle) } as i32 {
+            STATUS_ACCESS_DENIED => Err(RegKeyError::DeleteAccessDenied.into()),
+            STATUS_INVALID_HANDLE => Err(RegKeyError::DeleteInvalidHandle.into()),
+            _ => Ok(()),
+        }
+    }
+
+    /// delete a value
+    pub fn delete_value<S: AsRef<str>>(&self, value_name: S) -> Result<()> {
+        let mut unicode_string = UnicodeString::from(value_name.as_ref());
+        match unsafe { NtDeleteValueKey(self.handle, &mut unicode_string.0) } as i32 {
+            STATUS_ACCESS_DENIED => Err(crate::error::RegValueError::AccessDenied.into()),
+            STATUS_INSUFFICIENT_RESOURCES => {
+                Err(crate::error::RegValueError::InsufficientResources.into())
+            }
+            STATUS_INVALID_HANDLE => Err(RegValueError::InvalidHandle.into()),
+            STATUS_OBJECT_NAME_NOT_FOUND => Err(RegValueError::NameNotFound.into()),
+            _ => Ok(()),
+        }
+    }
+
+    fn open_key<S: AsRef<str>>(name: S, permission: u32) -> Result<RegKey> {
         let mut key = RegKey {
             handle: unsafe { zeroed() },
             name: {
-                let mut t = OsString::from(&name).encode_wide().collect::<Vec<u16>>();
+                let mut t = OsString::from(name.as_ref())
+                    .encode_wide()
+                    .collect::<Vec<u16>>();
                 t.push(0x00);
                 t
             },
@@ -101,20 +155,11 @@ impl RegKey {
                 null_mut(),
             );
         }
-        match unsafe { NtOpenKey(&mut key.handle, KEY_READ, &object_attr) } {
+
+        match unsafe { NtOpenKey(&mut key.handle, permission, &object_attr) } {
             0 => Ok(key),
-            err => Err(Error::KeyError(name, err)),
+            err => Err(Error::KeyError(name.as_ref().to_string(), err)),
         }
-    }
-
-    /// get an sub key enumerator
-    pub fn enum_keys(&self) -> RegKeyIterator {
-        RegKeyIterator::new(&self)
-    }
-
-    /// get a key value iterator
-    pub fn enum_values(&self) -> RegValueIterator {
-        RegValueIterator::new(&self.handle)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,9 @@ use winapi::{
             STATUS_OBJECT_NAME_NOT_FOUND,
         },
     },
-    um::winnt::{DELETE, KEY_READ, KEY_SET_VALUE, KEY_WRITE},
+    um::winnt::{
+        DELETE, KEY_READ, KEY_SET_VALUE, KEY_WRITE, REG_BINARY, REG_DWORD, REG_QWORD, REG_SZ,
+    },
 };
 
 /// Result wrapping WinRegNt errors
@@ -143,7 +145,7 @@ impl RegKey {
                 t.push(0x00);
                 t
             },
-            u: unsafe { zeroed() },
+            u: Default::default(),
         };
         key.u = UnicodeString::from(&key.name);
 
@@ -161,6 +163,93 @@ impl RegKey {
         match unsafe { NtOpenKey(&mut key.handle, permission, &object_attr) } {
             0 => Ok(key),
             err => Err(Error::KeyError(name.as_ref().to_string(), err)),
+        }
+    }
+
+    /// Create or update a binary value `name` with `value`
+    pub fn write_binary_value<S: AsRef<str>, V: AsRef<[u8]>>(
+        &mut self,
+        name: S,
+        value: V,
+    ) -> Result<()> {
+        let unicode_name = UnicodeString::from(name.as_ref());
+        match unsafe {
+            NtSetValueKey(
+                self.handle,
+                &unicode_name.0 as *const _ as *mut _,
+                0,
+                REG_BINARY,
+                value.as_ref() as *const _ as *mut _,
+                value.as_ref().len() as _,
+            )
+        } {
+            0 => Ok(()),
+
+            _ => Ok(()),
+        }
+    }
+
+    /// Create or update a binary value `name` with `value`
+    pub fn write_string_value<S: AsRef<str>, V: AsRef<str>>(
+        &mut self,
+        name: S,
+        value: V,
+    ) -> Result<()> {
+        let unicode_name = UnicodeString::from(name.as_ref());
+
+        let mut o = OsString::from(value.as_ref())
+            .encode_wide()
+            .collect::<Vec<u16>>();
+        o.push(0x00);
+
+        match unsafe {
+            NtSetValueKey(
+                self.handle,
+                &unicode_name.0 as *const _ as *mut _,
+                0,
+                REG_SZ,
+                o.as_mut_ptr() as _,
+                (o.len() * 2) as _,
+            )
+        } {
+            0 => Ok(()),
+            err => Err(RegValueError::Write(err).into()),
+        }
+    }
+
+    /// Create or update a binary value `name` with `value`
+    pub fn write_dword_value<S: AsRef<str>>(&mut self, name: S, value: u32) -> Result<()> {
+        let unicode_name = UnicodeString::from(name.as_ref());
+        match unsafe {
+            NtSetValueKey(
+                self.handle,
+                &unicode_name.0 as *const _ as *mut _,
+                0,
+                REG_DWORD,
+                &mut value.clone() as *const _ as *mut _,
+                std::mem::size_of::<u32>() as _,
+            )
+        } {
+            0 => Ok(()),
+            err => Err(RegValueError::Write(err).into()),
+        }
+    }
+
+    /// Create or update a `NONE` value `name` with `value`
+    pub fn write_qword_value<S: AsRef<str>>(&mut self, name: S, value: u64) -> Result<()> {
+        let unicode_name = UnicodeString::from(name.as_ref());
+        match unsafe {
+            NtSetValueKey(
+                self.handle,
+                &unicode_name.0 as *const _ as *mut _,
+                0,
+                REG_QWORD,
+                &mut value.clone() as *const _ as *mut _,
+                std::mem::size_of::<u64>() as _,
+            )
+        } {
+            0 => Ok(()),
+            err => Err(RegValueError::Write(err).into()),
         }
     }
 }

--- a/src/reg_key_iterator.rs
+++ b/src/reg_key_iterator.rs
@@ -100,6 +100,22 @@ impl<'a> RegSubkey<'a> {
         s.push_str(&self.name);
         RegKey::open(s)
     }
+
+    /// returns a `RegKey`
+    pub fn open_write(&'a self) -> Result<RegKey> {
+        let parent = {
+            let mut p = self.parent.to_vec();
+            p.pop();
+            p
+        };
+
+        let mut s = OsString::from_wide(&parent)
+            .into_string()
+            .map_err(|_| Into::<Error>::into(error::SubKeyError::ConvertName))?;
+        s.push_str("\\");
+        s.push_str(&self.name);
+        RegKey::open_write(s)
+    }
 }
 
 impl<'a> ::std::fmt::Display for RegSubkey<'a> {

--- a/src/unicode_string.rs
+++ b/src/unicode_string.rs
@@ -4,18 +4,25 @@ use std::mem::zeroed;
 use std::os::windows::ffi::OsStrExt;
 use winapi::shared::ntdef::UNICODE_STRING;
 
-pub(crate) struct UnicodeString(pub UNICODE_STRING);
+pub(crate) struct UnicodeString(pub UNICODE_STRING, Vec<u16>);
+
+impl Default for UnicodeString {
+    fn default() -> Self {
+        UnicodeString(unsafe { std::mem::zeroed() }, Vec::new())
+    }
+}
 
 impl From<&str> for UnicodeString {
     fn from(input: &str) -> Self {
         let mut u: UNICODE_STRING = unsafe { zeroed() };
         let mut o = OsString::from(input).encode_wide().collect::<Vec<u16>>();
         o.push(0x00);
+        o.push(0x00);
 
         unsafe {
             RtlInitUnicodeString(&mut u, o.as_ptr());
         }
-        UnicodeString(u)
+        UnicodeString(u, o)
     }
 }
 
@@ -25,7 +32,7 @@ impl From<&Vec<u16>> for UnicodeString {
         unsafe {
             RtlInitUnicodeString(&mut u, input.as_ptr());
         }
-        UnicodeString(u)
+        UnicodeString(u, input.to_vec())
     }
 }
 


### PR DESCRIPTION
added mutation routines to delete keys, delete values, and write/replace values.

also included is a change to the `UnicodeString` wrapper that prevents the underlying structure from going out of scope before we're done with it.